### PR TITLE
Fix documentation for state `next` functions.

### DIFF
--- a/lib/states/booklet.js
+++ b/lib/states/booklet.js
@@ -13,8 +13,12 @@ function BookletState(name, opts) {
 
     :param string name: name of the state
     :param fn_or_str opts.next:
-        state that the user should visit after this
-        state. Functions may return a promise.
+        state that the user should visit after this state. Functions should
+        have the form ``f(message_content [, done])`` and return the name of
+        the next state. If the ``done`` argument is present, ``f`` should
+        arrange for the name of the next state to be return asynchronously
+        using a call to ``done(state_name)``. The value of ``this`` inside
+        ``f`` will be the calling :class:`BookletState` instance.
     :param integer opts.pages:
         total number of pages.
     :param function opts.page_text:
@@ -31,7 +35,6 @@ function BookletState(name, opts) {
         ``"\n1 for prev, 2 for next, 0 to end."``
     :param object opts.handlers:
         object of handlers for particular events, see :class:`State`.
-    :type fn_or_str: ``Function`` or ``String``
     */
 
     var self = this;

--- a/lib/states/choices.js
+++ b/lib/states/choices.js
@@ -32,8 +32,12 @@ function ChoiceState(name, next, question, choices, error, handlers, options) {
     :param string name:
         name used to identify and refer to the state
     :param fn_or_str next:
-        state that the user should visit after this
-        state. Functions may return a promise.
+        state that the user should visit after this state. Functions should
+        have the form ``f(choice [, done])`` and return the name of
+        the next state. If the ``done`` argument is present, ``f`` should
+        arrange for the name of the next state to be return asynchronously
+        using a call to ``done(state_name)``. The value of ``this`` inside
+        ``f`` will be the calling :class:`ChoiceState` instance.
     :param string question:
         text to display to the user
     :param string error:
@@ -46,7 +50,6 @@ function ChoiceState(name, next, question, choices, error, handlers, options) {
         ``accept_labels`` is true, the state will accepts both "1" and "Red" as
         responses responses if the state's first choice is "Red". Defaults to
         ``false``.
-    :type fn_or_str: ``Function`` or ``String``
     */
 
     var self = this;

--- a/lib/states/end.js
+++ b/lib/states/end.js
@@ -16,8 +16,11 @@ function EndState(name, text, next, handlers) {
     :param string text:
         text to display to the user
     :param fn_or_str next:
-        state that the user should visit after this
-        state. Functions may return a promise.
+        state that the user should visit after this state. Functions should
+        have the form ``f(message_content)`` and return the name of the next
+        state. The value of ``this`` will be the calling :class:`EndState`
+        instance. If ``next`` is ``null``, the state machine will be left in
+        the current state.
     :param object handlers:
         object of handlers for particular events, see :class:`State`.
     :type fn_or_str: ``Function`` or ``String``

--- a/lib/states/freetext.js
+++ b/lib/states/freetext.js
@@ -13,8 +13,12 @@ function FreeText(name, next, question, check, error, handlers) {
     :param string name:
         name used to identify and refer to the state
     :param fn_or_str next:
-        state that the user should visit after this
-        state. Functions may return a promise.
+        state that the user should visit after this state. Functions should
+        have the form ``f(message_content [, done])`` and return the name of
+        the next state. If the ``done`` argument is present, ``f`` should
+        arrange for the name of the next state to be return asynchronously
+        using a call to ``done(state_name)``. The value of ``this`` inside
+        ``f`` will be the calling :class:`FreeText` instance.
     :param string question:
         text to display to the user
     :param function check:


### PR DESCRIPTION
Currently the documentation claims that these function may return promises which is incorrect. Rather, they may accept an additional `done` argument that is a function to call with the name of the next state once any asynchronous calls made by `next` have completed.
