### PR TITLE
Include data and status code when throwing an error in HttpApi

### DIFF
--- a/lib/http_api.js
+++ b/lib/http_api.js
@@ -99,7 +99,13 @@ var HttpRequest = Extendable.extend(function(self, method, url, opts) {
         Encodes the request data (if available).
         */
         if (self.data !== null) {
-            self.body = self.encoder(self.data);
+            try {
+                self.body = self.encoder(self.data);
+            }
+            catch (e) {
+                throw new HttpRequestError(
+                    self, "Could not parse request (" + e.toString() + ")");
+            }
         }
     };
 
@@ -185,7 +191,14 @@ var HttpResponse = Extendable.extend(function(self, request, code, opts) {
         Decodes the responses body (if available).
         */
         if (self.body !== null) {
-            self.data = self.decoder(self.body);
+
+            try {
+                self.data = self.decoder(self.body);
+            }
+            catch (e) {
+                throw new HttpResponseError(
+                    self, "Could not parse response (" + e.toString() + ")");
+            }
         }
     };
 
@@ -305,13 +318,7 @@ var HttpApi = Eventable.extend(function(self, im, opts) {
             decoder: self.decode_response_body
         });
 
-        try {
-            response.decode();
-        }
-        catch (e) {
-            throw new HttpResponseError(
-                response, "Could not parse response (" + e.toString() + ")");
-        }
+        response.decode();
 
         if (response.code < 200 || response.code >= 300) {
             throw new HttpResponseError(response);
@@ -348,14 +355,7 @@ var HttpApi = Eventable.extend(function(self, im, opts) {
         opts.encoder = self.encode_request_data;
 
         var request = new HttpRequest(method, url, opts);
-
-        try {
-            request.encode();
-        }
-        catch (e) {
-            throw new HttpRequestError(
-                request, "Could not parse request (" + e.toString() + ")");
-        }
+        request.encode();
 
         var cmd = request.to_cmd();
         return self

--- a/test/test_http_api.js
+++ b/test/test_http_api.js
@@ -62,6 +62,19 @@ describe("HttpRequest", function() {
             request.encode();
             assert.deepEqual(request.body, '{"foo":"bar"}');
         });
+
+        it("should throw an error if encoding fails", function() {
+            var request = new HttpRequest('GET', 'http://foo.com/', {
+                data: {foo: 'bar'},
+                encoder: function() {
+                    throw Error("You shall not parse");
+                }
+            });
+
+            assert.throws(function() {
+                request.encode();
+            }, HttpRequestError);
+        });
     });
 
     describe(".to_cmd", function() {
@@ -156,6 +169,19 @@ describe("HttpResponse", function() {
             });
             response.decode();
             assert.deepEqual(response.data, {foo: 'bar'});
+        });
+
+        it("should throw an error if decoding fails", function() {
+            var response = new HttpResponse(request, 404, {
+                body: '{"foo":"bar"}',
+                decoder: function() {
+                    throw Error("You shall not parse");
+                }
+            });
+
+            assert.throws(function() {
+                response.decode();
+            }, HttpResponseError);
         });
     });
 
@@ -406,13 +432,11 @@ describe("HttpApi", function() {
         });
 
         describe("if the body cannot be parsed", function() {
-            beforeEach(function() {
+            it("should throw an error", function() {
                 api.decode_response_body = function() {
                     throw Error("You shall not parse");
                 };
-            });
 
-            it("should throw an error", function() {
                 im.api.add_http_fixture({
                     request: {
                         method: 'GET',


### PR DESCRIPTION
This is the same as #59. I by mistake made a pull request with master as a base branch (sorry).
