### PR TITLE
Fix miscellaneous docstring issues.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -20,8 +20,8 @@ var App = Eventable.extend(function(self, start_state_name, opts) {
         name of the initial state. New users will enter this
         state when they first interact with the sandbox
         application.
-    :param opts.AppStates
-        Optional subclass of :class:`AppStates` to be used for creating 
+    :param opts.AppStates:
+        Optional subclass of :class:`AppStates` to be used for creating
         and managing states.
     */
     Eventable.call(self);
@@ -220,7 +220,7 @@ var AppStates = Eventable.extend(function(self, app) {
 
     self.creators.__error__ = function(name) {
         /**:AppStates.creators.__error__(name)
-         *
+
         Creates the fallback error state.
 
         :param string name:

--- a/lib/states/choices.js
+++ b/lib/states/choices.js
@@ -13,9 +13,11 @@ var Choice = Extendable.extend(function(self, value, label) {
     /**class:Choice(value, label)
     An individual choice that the user can select inside a :class:`ChoiceState`.
 
-    :param string value: string used when storing, processing and looking up
-    the choice.
-    :param string label: string displayed to the user.
+    :param string value:
+        string used when storing, processing and looking up
+        the choice.
+    :param string label:
+        string displayed to the user.
     */
     self.value = value;
     self.label = label;
@@ -32,7 +34,7 @@ var Choice = Extendable.extend(function(self, value, label) {
             label: self.label
         };
     };
-    
+
     self.toJSON = self.serialize;
 });
 

--- a/lib/states/state.js
+++ b/lib/states/state.js
@@ -14,16 +14,16 @@ var Eventable = events.Eventable;
 
 var StateError = BaseError.extend(function(self, message) {
     /**class:StateError(message)
-        Thrown when interacting or manipulating a state causes an error.
+    Thrown when interacting or manipulating a state causes an error.
 
-        :param string message: the error message.
+    :param string message: the error message.
     */
     self.name = 'StateError';
     self.message = message;
 });
 
 var StateEvent = Event.extend(function(self, name, state) {
-    /**:class.StateEvent(name, state, data)
+    /**class:StateEvent(name, state, data)
     An event relating to a state.
 
     :param string name: the event type's name.
@@ -34,9 +34,9 @@ var StateEvent = Event.extend(function(self, name, state) {
 });
 
 var StateInputEvent = StateEvent.extend(function(self, state, content) {
-    /**:class.StateInputEvent(content)
+    /**class:StateInputEvent(content)
     Emitted when the user has given input to the state.
-    
+
     :param State state: the state that the input was given to.
     :param string content: text from the user.
 
@@ -47,7 +47,7 @@ var StateInputEvent = StateEvent.extend(function(self, state, content) {
 });
 
 var StateEnterEvent = StateEvent.extend(function(self, state) {
-    /**:State.StateEnterEvent()
+    /**class:StateEnterEvent()
     Emitted when the state is entered by a user.
 
     :param State state: the state being entered.
@@ -58,7 +58,7 @@ var StateEnterEvent = StateEvent.extend(function(self, state) {
 });
 
 var StateExitEvent = StateEvent.extend(function(self, state) {
-    /**:State.StateEnterEvent()
+    /**class:StateEnterEvent()
     Called when the state is exited by the user.
 
     :param State state: the state being exited.
@@ -69,7 +69,7 @@ var StateExitEvent = StateEvent.extend(function(self, state) {
 });
 
 var State = Eventable.extend(function(self, name, opts) {
-    /**:State(name, opts)
+    /**class:State(name, opts)
     Base class for states in the interaction machine. States can be thought of
     as a single screen in a set of interactions with the user.
 
@@ -102,7 +102,7 @@ var State = Eventable.extend(function(self, name, opts) {
         /**:State.setup(im)
         Called before any other methods on the state are called to allow the
         state to set itself up.
-        
+
         :param InteractionMachine im: interaction machine using the state.
         */
         self.im = im;
@@ -123,7 +123,7 @@ var State = Eventable.extend(function(self, name, opts) {
         /**:State.save_response(response)
         Called by sub-classes to store accepted user responses on the user
         object.
-        
+
         :param string response: value to store as an answer.
         */
         self.im.user.set_answer(self.name, response);
@@ -140,7 +140,7 @@ var State = Eventable.extend(function(self, name, opts) {
         /**:State.translate(i18n)
         Translate any text that was not translated previously (this is a
         helper to make writing static states upfront easier).
-        
+
         :param Jed i18n: The jed instance to be used for translating the text.
         */
     };

--- a/lib/tester/checks.js
+++ b/lib/tester/checks.js
@@ -139,7 +139,7 @@ var CheckTasks = AppTesterTasks.extend(function(self, tester) {
 
         :param function fn:
             function that will be performing the assertions. Takes the form
-            ``func(im, api, app)``, where ``im` is the tester's
+            ``func(im, api, app)``, where ``im`` is the tester's
             :class:`InteractionMachine` instance, ``api`` is the tester's
             api instance (by default an instance of :class:`DummyApi`) and
             ``app`` is the sandbox app being tested. May return a promise.

--- a/lib/tester/interactions.js
+++ b/lib/tester/interactions.js
@@ -70,8 +70,8 @@ var InteractionTasks = AppTesterTasks.extend(function(self, tester) {
         Updates the content of the message to be sent from the user into the
         sandbox to be null and defaults the message's session event type to
         'new'. Typically used to test starting up a session with the user.
-        Alias to `AppTester.start().
-        
+        Alias to :func:`AppTester.start`.
+
         .. code-block:: javascript
 
             tester.input();
@@ -80,7 +80,7 @@ var InteractionTasks = AppTesterTasks.extend(function(self, tester) {
 
         Updates the message to be sent from the user into the sandbox with the
         properties given in ``obj``.
-        
+
         :param object obj:
             the properties to update on the message to be sent
 
@@ -158,7 +158,7 @@ var InteractionTasks = AppTesterTasks.extend(function(self, tester) {
         Updates the content of the message to be sent from the user into the
         sandbox to be null and defaults the message's session event type to
         'new'. Typically used to test starting up a session with the user.
-        
+
         .. code-block:: javascript
 
             tester.begin();
@@ -180,15 +180,15 @@ var InteractionTasks = AppTesterTasks.extend(function(self, tester) {
         The following session event values are recognised:
 
             * ``'new'``: used to signal the start of the session, where the
-            session has been initiated by the user. The content of the
-            message is irrelevant.
+              session has been initiated by the user. The content of the
+              message is irrelevant.
 
             * ``'resume'``: a common message sent in from the user during a
-            session
+              session
 
             * ``'close'``: used to signal the end of the session, where the
-            session has been terminated by the user. The content of the
-            message is irrelevant.
+              session has been terminated by the user. The content of the
+              message is irrelevant.
 
         .. code-block:: javascript
 


### PR DESCRIPTION
Currently building the docs shows:

```
/vumi-jssandbox-toolkit/docs/app.rst:11: WARNING: Field list ends without a blank line; unexpected unindent.
/vumi-jssandbox-toolkit/docs/app.rst:91: WARNING: Block quote ends without a blank line; unexpected unindent.
/vumi-jssandbox-toolkit/docs/states.rst:7: WARNING: Field list ends without a blank line; unexpected unindent.
/vumi-jssandbox-toolkit/docs/tester.rst:26: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/vumi-jssandbox-toolkit/docs/tester.rst:92: WARNING: Bullet list ends without a blank line; unexpected unindent.
/vumi-jssandbox-toolkit/docs/tester.rst:96: WARNING: Bullet list ends without a blank line; unexpected unindent.
/vumi-jssandbox-toolkit/docs/tester.rst:99: WARNING: Bullet list ends without a blank line; unexpected unindent.
/vumi-jssandbox-toolkit/docs/user.rst:126: WARNING: duplicate object description of setup, other instance in /vumi-jssandbox-toolkit/docs/states.rst
```
