### PR TITLE
InteractionMachine.attach call should happen last

### DIFF
--- a/lib/interaction_machine.js
+++ b/lib/interaction_machine.js
@@ -270,7 +270,6 @@ var InteractionMachine = Eventable.extend(function(self, api, app) {
             self.emit(e).done(done, err);
         };
     };
-    self.attach();
 
     self.setup = function(msg, opts) {
         /**:InteractionMachine.setup(msg[, opts])
@@ -712,6 +711,8 @@ var InteractionMachine = Eventable.extend(function(self, api, app) {
                 return self.handle_message(msg);
             });
     });
+
+    self.attach();
 });
 
 


### PR DESCRIPTION
We are currently calling `InteractionMachine.attach()` before `.done` and `.err` are defined.
