### PR TITLE
Users get stuck in __error__ states

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -330,18 +330,11 @@ var AppStates = Eventable.extend(function(self, app) {
         This default implementation creates an EndState with name
         ``name`` and content *"An error occurred. Please try again later"*.
 
-        The end state created has the next state set to ``null``. When the
-        state receives input, it will invoke :meth:`UserStateData.change` to
-        change the user's current state. Since the state given to it is
-        ``null``, it will instead stay on the current state.
-
-        If we are dealing with a new user, then the :class:`InteractionMachine`
-        will have requested the start state to have been created. If the start
-        state does not exist, we will end up here again, ensuring the same
-        message will be displayed.
+        The end state created has the next state set to the start state.  If
+        the start state does not exist, we in the error state again..
         */
         return new EndState(name, {
-            next: null,
+            next: self.app.start_state_name,
             text: "An error occurred. Please try again later."
         });
     };

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -5,7 +5,9 @@ var test_utils = vumigo.test_utils;
 var State = vumigo.states.State;
 
 var app = vumigo.app;
+var App = app.App;
 var AppStateError = app.AppStateError;
+var AppTester = vumigo.AppTester;
 
 
 describe("AppStates", function () {
@@ -159,13 +161,7 @@ describe("AppStates", function () {
 
                 it("should create the error state", function() {
                     return states.create('spam').then(function(new_state) {
-                        assert.equal(
-                            new_state.name,
-                            '__error__');
-
-                        assert.equal(
-                            new_state.end_text,
-                            'An error occurred. Please try again later.');
+                        assert.equal(new_state.name, '__error__');
                     });
                 });
             });
@@ -205,14 +201,35 @@ describe("AppStates", function () {
 
             it("should create the error state", function() {
                 return states.create('bad').then(function(new_state) {
-                    assert.equal(
-                        new_state.name,
-                        '__error__');
-
-                    assert.equal(
-                        new_state.end_text,
-                        'An error occurred. Please try again later.');
+                    assert.equal(new_state.name, '__error__');
                 });
+            });
+        });
+    });
+
+    describe(".creators", function() {
+        describe(".__error__", function() {
+            it("should display an appropriate message to the user", function() {
+                var app = new App('__error__');
+                var tester = new AppTester(app);
+
+                return tester
+                    .start()
+                    .check.reply('An error occurred. Please try again later.')
+                    .run();
+            });
+
+            it("should put the user in the start state on the next session",
+            function() {
+                var app = new App('start');
+                var tester = new AppTester(app);
+                app.states.add(new State('start'));
+
+                return tester
+                    .setup.user.state('__error__')
+                    .start()
+                    .check.user.state('start')
+                    .run();
             });
         });
     });


### PR DESCRIPTION
Once a user has reached an `__error__` state, the state name stored for them is `__error__` and there is no way of them getting out of it.
