### PR TITLE
Add MenuState.

### DIFF
--- a/lib/states/choices.js
+++ b/lib/states/choices.js
@@ -206,6 +206,25 @@ var ChoiceState = State.extend(function(self, name, opts) {
 });
 
 
+var MenuState = ChoiceState.extend(function(self, name, opts) {
+    /**class:MenuState(name, opts)
+
+    A :class:`ChoiceState` whose :class:`Choice` values are either state names
+    or state options objects. See :meth:`State.set_next_state` for a
+    description of the options objects.
+
+    Supports the same parameters as :class:`ChoiceState` except that
+    ``opts.next`` isn't available.
+    */
+
+    opts.next = function(choice) {
+        return choice.value;
+    };
+
+    ChoiceState.call(self, name, opts);
+});
+
+
 var LanguageChoice = ChoiceState.extend(function(self, name, opts) {
     /**class:LanguageChoice(opts)
 
@@ -422,3 +441,4 @@ this.Choice = Choice;
 this.ChoiceState = ChoiceState;
 this.LanguageChoice = LanguageChoice;
 this.PaginatedChoiceState = PaginatedChoiceState;
+this.MenuState = MenuState;

--- a/lib/states/index.js
+++ b/lib/states/index.js
@@ -20,6 +20,7 @@ this.State = state.State;
 this.BookletState = booklet.BookletState;
 this.Choice = choices.Choice;
 this.ChoiceState = choices.ChoiceState;
+this.MenuState = choices.MenuState;
 this.LanguageChoice = choices.LanguageChoice;
 this.PaginatedChoiceState = choices.PaginatedChoiceState;
 this.FreeText = freetext.FreeText;


### PR DESCRIPTION
Menus for selecting one of a set of following states are pretty common:

``` javascript
self.states.add('states:main_menu', function(name) {
            return new ChoiceState(name, {
                question: "Ureport (Speak out for your community)",
                choices: [
                    new Choice('poll', "This week's question"),
                    new Choice('results', 'Poll results'),
                    new Choice('reports', 'Send report')
                ],
                next: function(choice) {
                    return {
                        poll: 'states:poll:question',
                        results: 'states:results:choose',
                        reports: 'states:reports:submit'
                    }[choice.value];
                }
            });
        });
```

Would be nice to be able to write these as:

``` javascript
self.states.add('states:main_menu', function(name) {
            return new MenuState(name, {
                question: "Ureport (Speak out for your community)",
                choices: [
                    new Choice('states:poll:question', "This week's question"),
                    new Choice('states:results:choose', 'Poll results'),
                    new Choice('states:reports:submit', 'Send report')
                ]
            });
        });
```
