### PR TITLE
Bind the tester instance to setup functions

### DIFF
--- a/lib/tester/interactions.js
+++ b/lib/tester/interactions.js
@@ -122,7 +122,7 @@ var InteractionTasks = AppTesterTasks.extend(function(self, tester) {
             return;
         }
         else if (typeof v == 'function') {
-            return Q(v)
+            return Q(v.bind(self.tester))
                .fcall(self.data.msg)
                .then(function(result) {
                    self.data.msg = result;

--- a/lib/tester/setups.js
+++ b/lib/tester/setups.js
@@ -140,7 +140,7 @@ var SetupTasks = AppTesterTasks.extend(function(self, tester) {
             _.extend(self.data.user, v);
             return;
         } else {
-            return Q(v)
+            return Q(v.bind(self.tester))
                 .fcall(self.data.user)
                 .then(function(result) {
                     self.data.user = result;

--- a/test/test_tester/test_interaction.js
+++ b/test/test_tester/test_interaction.js
@@ -154,6 +154,15 @@ describe("AppTester Interaction Tasks", function() {
                         assert.equal(im.msg.session_event, 'resume');
                     });
             });
+
+            it("should bind the function to the tester instance", function() {
+                return tester
+                    .input(function(msg) {
+                        assert.strictEqual(this, tester);
+                        return {};
+                    })
+                    .run();
+            });
         });
 
         describe(".input(content)", function() {

--- a/test/test_tester/test_setup.js
+++ b/test/test_tester/test_setup.js
@@ -142,6 +142,14 @@ describe("AppTester Setup Tasks", function() {
                     assert.equal(user.addr, '+81');
                 });
             });
+
+            it("should bind the function to the tester instance", function() {
+                return tester.setup.user(function() {
+                    assert.strictEqual(this, tester);
+                    return {};
+                })
+                .run();
+            });
         });
     });
 


### PR DESCRIPTION
The `AppTester` docs claim that `this` is the tester instance for setup functions, but we actually don't do this.
