### PR TITLE
Allow url params to be included in the url for http fixtures

### DIFF
--- a/lib/http/dummy.js
+++ b/lib/http/dummy.js
@@ -32,7 +32,9 @@ var HttpFixture = Extendable.extend(function(self, opts) {
     :type opts.request.url:
         string or :class:`RegExp`
     :param opts.request.url:
-        The request url
+        The request url. If a string is given, the url may include params.  If
+        the params are included, these will be decoded and set as the
+        :class:`HttpRequest`\'s params.
     :param string opts.request.method:
         The request method. Defaults to 'GET'.
     :param object opts.request.data:
@@ -42,7 +44,8 @@ var HttpFixture = Extendable.extend(function(self, opts) {
     :type opts.request.params:
         object or array
     :param opts.request.params:
-        The request's params. See :class:`UrlParams`
+        The request's params. See :class:`UrlParams`. If the url params are
+        included in the url, those params will be used instead.
     :param object opts.request.headers:
         An object mapping each header name to an array of header values.
     :param object opts.response:
@@ -95,10 +98,21 @@ var HttpFixture = Extendable.extend(function(self, opts) {
     self.parse = {};
 
     self.parse.request = function(request) {
+        var url = request.url;
+
         _.defaults(request, self.defaults.request);
         request.encoder = self.encoding.encoder;
 
-        request = new HttpRequest(request.method, request.url, request);
+        if (!_.isRegExp(request.url)) {
+            var parts = utils.url_decode(request.url);
+            url = parts.url;
+
+            if (_.size(parts.params)) {
+                request.params = parts.params;
+            }
+        }
+
+        request = new HttpRequest(request.method, url, request);
         request.encode();
         return request;
     };

--- a/test/test_http/test_dummy.js
+++ b/test/test_http/test_dummy.js
@@ -43,6 +43,21 @@ describe("http.dummy", function() {
             assert.equal(fixture.responses[0].code, 200);
         });
 
+        it("should use params given in the url if relevant", function() {
+            var fixture = new HttpFixture({
+                request: {
+                    url: 'http://example.com/?foo=b%20a%20r',
+                    params: {foo: 'baz'}
+                }
+            });
+
+            assert.equal(fixture.request.url, 'http://example.com/');
+            assert.deepEqual(fixture.request.params.toJSON(), [{
+                name: 'foo',
+                value: 'b a r'
+            }]);
+        });
+
         it("should encode requests", function() {
             var fixture = new HttpFixture({
                 default_encoding: 'json',


### PR DESCRIPTION
Currently, url params have to be given separately.
