### PR TITLE
Creator opts don't get saved for the user for delegate states

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -324,6 +324,14 @@ var AppStates = Eventable.extend(function(self, app) {
             })
             .then(function(state) {
                 self.check(state, name);
+
+                // Ensure we can recreate the state with the same creator
+                // opts when the state is recreated next sandbox run. Needed
+                // for cases where create() is called inside a state creator
+                if (!('__creator_opts__' in state)) {
+                    state.__creator_opts__ = opts;
+                }
+
                 return state;
             })
             .catch(function(e) {

--- a/lib/interaction_machine.js
+++ b/lib/interaction_machine.js
@@ -468,9 +468,12 @@ var InteractionMachine = Eventable.extend(function(self, api, app) {
                 })
                 .then(function() {
                     self.state = new_state;
+
                     self.user.state.reset(new_state, {
-                        creator_opts: creator_opts
+                        creator_opts: new_state.__creator_opts__
                     });
+
+                    delete new_state.__creator_opts__;
                     return self.emit.state.enter(new_state);
                 });
         });

--- a/test/test_interaction_machine.js
+++ b/test/test_interaction_machine.js
@@ -399,7 +399,7 @@ describe("interaction_machine", function() {
                 });
             });
 
-            it.only("should save the right opts for delegate state creators",
+            it("should save the right opts for delegate state creators",
             function() {
                 assert(_.isUndefined(im.user.creator_opts));
 


### PR DESCRIPTION
We currently are only saving creator opts for states referred to from another state's `.next` callback, but not for cases like this:

``` javascript
self.states.add('states:foo', function() {
  return self.states.create('states:bar', {
      baz: 'qux'
  });
});
```
