### PR TITLE
Dummy kv resource should initialise non-existent keys on .incr

### DIFF
--- a/lib/kv/dummy.js
+++ b/lib/kv/dummy.js
@@ -47,7 +47,10 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
             ].join(' '));
         }
 
-        var value = self.store[key];
+        var value = key in self.store
+            ? self.store[key]
+            : 0;
+
         if (!utils.is_integer(value)) {
             throw new DummyResourceError([
                 "Cannot increment non-integer value for key",

--- a/test/test_kv/test_dummy.js
+++ b/test/test_kv/test_dummy.js
@@ -30,6 +30,11 @@ describe("kv.dummy", function() {
                 assert.equal(api.kv.store.foo, 3);
             });
 
+            it("should initialise new keys", function() {
+                assert.strictEqual(api.kv.incr('foo'), 1);
+                assert.equal(api.kv.store.foo, 1);
+            });
+
             it("should throw an error for non-integer values", function() {
                 api.kv.store.foo = 'bar';
 


### PR DESCRIPTION
Right now, it throws an error instead, this is not what the actual api does.
