### PR TITLE
Use json as the default encoding for fixtures

### DIFF
--- a/examples/http/test/app.test.js
+++ b/examples/http/test/app.test.js
@@ -13,12 +13,7 @@ describe("app", function() {
         
         beforeEach(function() {
             app = new HttpApp();
-
-            // We set up the `DummyApi`'s http resource to use 'json' as the
-            // default encoding. This can be overriden in each fixture.
-            tester = new AppTester(app, {
-                api: {http: {default_encoding: 'json'}}
-            });
+            tester = new AppTester(app);
 
             tester
                 .setup.config.app({

--- a/lib/http/dummy.js
+++ b/lib/http/dummy.js
@@ -280,7 +280,7 @@ var DummyHttpResource = DummyResource.extend(function(self, name, opts) {
         header is set, the encoding is inferred using that instead.
     */
     DummyResource.call(self, name);
-    opts = _.defaults(opts || {}, {default_encoding: 'none'});
+    opts = _.defaults(opts || {}, {default_encoding: 'json'});
     self.encoding = encodings[opts.default_encoding];
 
     /**attribute:DummyHttpResource.requests

--- a/test/test_http/test_api.js
+++ b/test/test_http/test_api.js
@@ -217,7 +217,9 @@ describe("http.api", function() {
         var api;
 
         function make_api(opts) {
-            return test_utils.make_im().then(function(new_im) {
+            return test_utils.make_im({
+                api: {http: {default_encoding: 'none'}}
+            }).then(function(new_im) {
                 im = new_im;
                 api = new HttpApi(im, opts);
                 return api;


### PR DESCRIPTION
This is the a pretty common case, might help to not need this to be specified explicitly.
