### PR TITLE
Change .fire.inc to use last aggregation and the kv store

### DIFF
--- a/lib/metrics/api.js
+++ b/lib/metrics/api.js
@@ -100,8 +100,8 @@ var MetricStore = Eventable.extend(function(self, im) {
     */
     self.support_agg('last');
 
-    self.inc = function(metric, opts) {
-        /**:MetricStore.inc(metric[, opts])
+    self.fire.inc = function(metric, opts) {
+        /**:MetricStore.fire.inc(metric[, opts])
 
         Increments the value for the key ``metric`` in in the kv store, fires a
         metric with the new total using the ``'last`` aggregation method, then

--- a/test/test_metrics/test_api.js
+++ b/test/test_metrics/test_api.js
@@ -198,12 +198,12 @@ describe("metrics.api", function() {
             });
         });
 
-        describe(".inc", function() {
+        describe(".fire.inc", function() {
             it("should increment the associated kv key", function() {
                 api.kv.store['test_app.yaddle_the_metric'] = 3;
 
                 return metrics
-                    .inc('yaddle_the_metric', {amount: 2})
+                    .fire.inc('yaddle_the_metric', {amount: 2})
                     .then(function() {
                         assert.equal(
                             api.kv.store['test_app.yaddle_the_metric'], 5);
@@ -214,7 +214,7 @@ describe("metrics.api", function() {
                 api.kv.store['test_app.yaddle_the_metric'] = 3;
 
                 return metrics
-                    .inc('yaddle_the_metric')
+                    .fire.inc('yaddle_the_metric')
                     .then(function(total) {
                         assert.equal(total, 4);
                     });
@@ -225,9 +225,9 @@ describe("metrics.api", function() {
                 api.kv.store['test_app.yaddle_the_metric'] = 3;
 
                 return Q.all([
-                    metrics.inc('yoda_the_metric'),
-                    metrics.inc('yoda_the_metric'),
-                    metrics.inc('yaddle_the_metric')
+                    metrics.fire.inc('yoda_the_metric'),
+                    metrics.fire.inc('yoda_the_metric'),
+                    metrics.fire.inc('yaddle_the_metric')
                 ]).then(function() {
                     assert.deepEqual(im.api.metrics.stores, {
                         test_app:{


### PR DESCRIPTION
This will be easier for graphite to handle and allows the user to get back the current total.
