### PR TITLE
Add address type inference for mxit and wechat

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -140,11 +140,12 @@ function infer_addr_type(delivery_class) {
 
     A ``delivery class`` is type of system that messages can
     be sent or received over. Common values are ``sms``, ``ussd``,
-    ``gtalk`` and ``twitter``.
+    ``gtalk``, ``twitter``, ``mxit`` and ``wechat``.
 
     An ``address type`` is a type of address used to identify a user
     and corresponds to a field on a :class:`Contact` object. Common
-    values are ``msisdn``, ``gtalk_id`` and ``twitter_handler``.
+    values are ``msisdn``, ``gtalk_id`` and ``twitter_handler``,
+    ``mxit_id`` and ``wechat_id`.
 
     If the ``delivery_class`` isn't know, the ``delivery_class``
     itself is returned as the ``address_type``.
@@ -162,7 +163,9 @@ function infer_addr_type(delivery_class) {
         sms: 'msisdn',
         ussd: 'msisdn',
         gtalk: 'gtalk_id',
-        twitter: 'twitter_handle'
+        twitter: 'twitter_handle',
+        mxit: 'mxit_id',
+        wechat: 'wechat_id'
     }[delivery_class];
 }
 

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -150,6 +150,14 @@ describe("utils", function() {
             assert.equal(utils.infer_addr_type('twitter'), 'twitter_handle');
         });
 
+        it("should infer the address type for mxit", function() {
+            assert.equal(utils.infer_addr_type('mxit'), 'mxit_id');
+        });
+
+        it("should infer the address type for wechat", function() {
+            assert.equal(utils.infer_addr_type('wechat'), 'wechat_id');
+        });
+
         it("should return undefined for unrecognized delivery classes",
         function() {
             assert.equal(


### PR DESCRIPTION
We currently don't do any inference for these.
