### PR TITLE
BookletStates shouldn't allow going backwards from page 0

### DIFF
--- a/lib/states/booklet.js
+++ b/lib/states/booklet.js
@@ -99,12 +99,7 @@ var BookletState = State.extend(function(self, name, opts) {
 
     self.inc_current_page = function(amount) {
         var page = self.get_current_page() + amount;
-
-        page = page % self.pages;
-        if (page < 0) {
-            page += self.pages;
-        }
-
+        page = Math.max(Math.min(page, self.pages - 1), 0);
         self.set_current_page(page);
     };
 

--- a/test/test_states/test_booklet.js
+++ b/test/test_states/test_booklet.js
@@ -39,6 +39,36 @@ describe("states.booklet", function() {
             tester.data.opts = {};
         });
 
+        it("should stay on page 0 when the user tries go back on it",
+        function() {
+            return tester
+                .setup.user.state({
+                    name: 'states:test',
+                    metadata: {page: 0}
+                })
+                .input('1')
+                .check.reply([
+                    "Page 0.",
+                    "1 for prev, 2 for next, 0 to end."
+                ].join('\n'))
+                .run();
+        });
+
+        it("should stay on the last page when the user tries go forward on it",
+        function() {
+            return tester
+                .setup.user.state({
+                    name: 'states:test',
+                    metadata: {page: 2}
+                })
+                .input('2')
+                .check.reply([
+                    "Page 2.",
+                    "1 for prev, 2 for next, 0 to end."
+                ].join('\n'))
+                .run();
+        });
+
         it("should display the first page when the user enters", function() {
             return tester
                 .input()


### PR DESCRIPTION
At the moment, if the user selects 'prev' on the first page of a booklet state, they are taken to the last page. It might make more sense to clamp the page between the first and last page instead.
