### PR TITLE
App's opts.AppStates doesn't get used

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -111,7 +111,7 @@ var App = Eventable.extend(function(self, start_state_name, opts) {
     self.im = null;
     self.start_state_name = start_state_name;
     self.events = opts.events;
-    self.AppStates = AppStates;
+    self.AppStates = opts.AppStates;
     self.states = new self.AppStates(self);
 
     /**attribute:App.$


### PR DESCRIPTION
s/`AppStates`/`opts.AppStates`. Duplicate of #178, since that was opened against master instead of develop.
