### PR TITLE
Dummy Metric Store should warn against using invalid characters

### DIFF
--- a/lib/metrics/dummy.js
+++ b/lib/metrics/dummy.js
@@ -5,7 +5,7 @@ var DummyResourceError = resources.DummyResourceError;
 
 var DummyMetricsResource = DummyResource.extend(function(self, name) {
     /**class:DummyMetricsResource(name)
-    
+
     Handles api requests to the metrics resource from :class:`DummyApi`.
 
     :param string name:
@@ -22,6 +22,7 @@ var DummyMetricsResource = DummyResource.extend(function(self, name) {
     that have been fired to the store with the name ``store_name``.
     */
     self.stores = {};
+    self.metric_pattern = /^[a-zA-Z][a-zA-Z0-9._]{0,100}$/;
 
     self.ensure_metric = function(data) {
         var store = self.stores[data.store] || {};
@@ -50,6 +51,13 @@ var DummyMetricsResource = DummyResource.extend(function(self, name) {
         :param number data.value:
             the value to store for the metric
         */
+        if (!self.metric_pattern.test(data.metric)) {
+            throw new DummyResourceError([
+                "Metric name '" + data.metric + "' is invalid. It should",
+                "match '" + self.metric_pattern.source + "'.",
+            ].join(' '));
+        }
+
         var metric = self.ensure_metric(data);
 
         if (data.agg !== metric.agg) {

--- a/test/test_metrics/test_dummy.js
+++ b/test/test_metrics/test_dummy.js
@@ -121,6 +121,28 @@ describe("metrics.dummy", function() {
                         return true;
                     });
             });
+
+            it("should fail if an invalid metric name is given", function() {
+                assert.throws(
+                    function() {
+                        api.metrics.record({
+                            store: 'store',
+                            metric: 'bad-metric',
+                            agg: 'avg',
+                            value: 2
+                        });
+                    },
+                    function(e) {
+                        assert(e instanceof DummyResourceError);
+                        assert.equal(
+                            e.message,
+                            ["Metric name 'bad-metric' is invalid. It should",
+                             "match '^[a-zA-Z][a-zA-Z0-9._]{0,100}$'.",
+                            ].join(' '));
+
+                        return true;
+                    });
+            });
         });
 
         describe(".handlers", function() {


### PR DESCRIPTION
For example we used state name as part of a metric name and that state name had a `:` in it so it errored in production
