### PR TITLE
Explicitly return a StateInvalidError from ChoiceState.check.

### DIFF
--- a/lib/states/state.js
+++ b/lib/states/state.js
@@ -321,9 +321,10 @@ var State = Eventable.extend(function(self, name, opts) {
             }
             else {
                 throw new StateError(self, [
-                    ".check() may only return strings or",
-                    "instances of LazyText or StateInvalidError",
-                ].join(" "));
+                    ".check() may only return null or undefined (to indicate",
+                    " success), or string, LazyText or StateInvalidError",
+                    " objects (to indicate errors)",
+                ].join(""));
             }
 
             return self.invalidate(error);

--- a/test/test_states/test_state.js
+++ b/test/test_states/test_state.js
@@ -447,9 +447,11 @@ describe("states.state", function() {
                         })
                         .then(function() {
                             assert.deepEqual(error, new StateError(state, [
-                                ".check() may only return strings or instances of",
-                                "LazyText or StateInvalidError",
-                            ].join(" ")));
+                                ".check() may only return null or undefined",
+                                " (to indicate success), or string, LazyText",
+                                " or StateInvalidError objects (to indicate",
+                                " errors)",
+                            ].join("")));
                         });
                 });
             });


### PR DESCRIPTION
Not doing so means `self.error_text` is returned which could easily be something strange that `State.validate` doesn't recognize as an error.
