### PR TITLE
Add support for verify_options to HTTP API helpers

### DIFF
--- a/lib/http/api.js
+++ b/lib/http/api.js
@@ -79,6 +79,8 @@ var HttpRequest = Extendable.extend(function(self, method, url, opts) {
         module
     :param string opts.verify_options:
         A list of options to verify when doing an HTTPS request. Optional.
+    :param string opts.ssl_method:
+        A request for a specific ssl method to be attempted. Optional.
     */
     Extendable.call(self);
 
@@ -88,7 +90,8 @@ var HttpRequest = Extendable.extend(function(self, method, url, opts) {
         data: null,
         params: {},
         encoder: _.identity,
-        verify_options: null
+        verify_options: null,
+        ssl_method: null
     });
 
     self.url = url;
@@ -103,6 +106,7 @@ var HttpRequest = Extendable.extend(function(self, method, url, opts) {
     self.params = opts.params;
     self.encoder = opts.encoder;
     self.verify_options = opts.verify_options;
+    self.ssl_method = opts.ssl_method;
 
     self.encode = function() {
         /**:HttpRequest.encode()
@@ -144,6 +148,10 @@ var HttpRequest = Extendable.extend(function(self, method, url, opts) {
 
         if (self.verify_options !== null) {
             cmd.data.verify_options = self.verify_options;
+        }
+
+        if (self.ssl_method !== null) {
+            cmd.data.ssl_method = self.ssl_method;
         }
         
         return cmd;

--- a/test/test_http/test_api.js
+++ b/test/test_http/test_api.js
@@ -134,6 +134,15 @@ describe("http.api", function() {
                 var cmd = request.to_cmd();
                 assert.deepEqual(cmd.data.verify_options, ['VERIFY_NONE']);
             });
+
+            it("should include the ssl_method param if passed as an string", function() {
+                var request = new HttpRequest('GET', 'https://foo.com/', {
+                    ssl_method: "SSLv3"
+                });
+
+                var cmd = request.to_cmd();
+                assert.deepEqual(cmd.data.ssl_method, "SSLv3");
+            });
         });
 
         describe(".toString", function() {


### PR DESCRIPTION
See https://github.com/praekelt/vumi/blob/develop/vumi/application/sandbox.py#L791-L796 for the low-level implementation.
