### PR TITLE
Add MSISDN normalization utility.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -272,6 +272,40 @@ pretty.object = function(obj, opts) {
         .value();
 };
 
+normalize_msisdn = function(number, country_code) {
+    /**function:normalize_msisdn(number, country_code)
+    Normalizes an MSISDN number.
+
+    This function will normalize an MSISDN number by removing any invalid
+    characters and adding the country code. It will return null if the given
+    number cannot be normalized.
+
+    This function is based on the MSISDN normalize function found within the
+    vumi utils.
+
+    :param string number:
+        The number to normalize.
+    :param string country_code:
+        (optional) The country code for the number.
+    */
+
+    // Remove invalid characters
+    number = number.replace(/[^0-9+]/g, '');
+    // Don't touch shortcodes
+    if (number.length <= 5) return number;
+    // Handle ``00`` case
+    number = number.replace(/^0{2}/, '+');
+    if(country_code){
+        country_code = country_code.replace(/\+/g, '');
+        // Handle ``0`` case
+        number = number.replace(/^0/, ['+',country_code].join(''));
+        // Add ``+``
+        if(number.match('^' + country_code)) {
+            number = ['+',number].join('');
+        }
+    }
+    return (number.match(/^\+/)) ? number : null;
+};
 
 function Extendable() {
     /**class:Extendable()
@@ -360,6 +394,7 @@ this.infer_addr_type = infer_addr_type;
 this.format_addr = format_addr;
 this.indent = indent;
 this.pretty = pretty;
+this.normalize_msisdn = normalize_msisdn;
 this.Extendable = Extendable;
 this.BaseError = BaseError;
 this.DeprectationError = DeprecationError;

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -253,4 +253,38 @@ describe("utils", function() {
                 ].join('\n'));
         });
     });
+
+    describe(".normalize_msisdn", function() {
+        it("Should remove invalid characters", function() {
+            assert.equal(utils.normalize_msisdn('+12ab5 7','27'), '+1257');
+        });
+
+        it("Should not touch shortcodes", function() {
+            assert.equal(utils.normalize_msisdn('12345'), '12345');
+        });
+
+        it("Should handle ``00`` case", function() {
+            assert.equal(utils.normalize_msisdn('0027741234567','27'),
+                '+27741234567');
+        });
+
+        it("Should handle the `0` case", function() {
+            assert.equal(utils.normalize_msisdn('0741234567','27'),
+                '+27741234567');
+        });
+
+        it("Should add the ``+`` in the case of country code", function() {
+            assert.equal(utils.normalize_msisdn('27741234567','27'),
+                '+27741234567');
+        });
+
+        it("Should return null for incorrect numbers", function() {
+            assert.equal(utils.normalize_msisdn('123456789','27'), null);
+        });
+
+        it("Should handle ``+`` symbol in country code", function() {
+            assert.equal(utils.normalize_msisdn('0741234567','+27'),
+                '+27741234567');
+        });
+    });
 });


### PR DESCRIPTION
This is mostly to support MSISDNs input by users. Addresses set by Vumi Go should already be correctly normalized.

See praekelt/vumi-go#829 for original ticket.
