### PR TITLE
Allow a fixture to be repeatable

### DIFF
--- a/lib/http/dummy.js
+++ b/lib/http/dummy.js
@@ -143,13 +143,15 @@ var HttpFixture = Extendable.extend(function(self, opts) {
         /**:HttpFixture.use()
         Returns the fixture's next unused :class:`HttpResponse`.
         */
-        if (!self.repeatable && self.uses === self.responses.length) {
+        var len = self.responses.length;
+
+        if (!self.repeatable && self.uses === len) {
             throw new DummyResourceError([
                 "All of the fixture's responses have been used up: " + self
             ].join(' '));
         }
 
-        return self.responses[self.uses++];
+        return self.responses[Math.min(self.uses++, len - 1)];
     };
 
     self.serialize = function() {

--- a/test/test_http/test_dummy.js
+++ b/test/test_http/test_dummy.js
@@ -109,18 +109,18 @@ describe("http.dummy", function() {
                 }, DummyResourceError);
             });
 
-            it("should not throw an error the response is repeatable", function() {
+            it("should allow fixtures to be repeatable", function() {
                 var fixture = new HttpFixture({
                     repeatable: true,
                     request: {url: 'http://example.com'},
-                    responses: [
-                        {body: '{"foo":"bar"}'},
-                        {body: '{"baz":"qux"}'}]
+                    response: {body: '{"foo":"bar"}'}
                 });
 
-                fixture.use();
-                fixture.use();
-                fixture.use();
+                assert.deepEqual([fixture.use()], fixture.responses);
+                assert.deepEqual([fixture.use()], fixture.responses);
+                assert.deepEqual([fixture.use()], fixture.responses);
+                assert.deepEqual([fixture.use()], fixture.responses);
+                assert.deepEqual([fixture.use()], fixture.responses);
             });
         });
 


### PR DESCRIPTION
At the moment, fixtures have limited uses. We need to allow the option of having a fixture's reponse be sent out as many times as it gets requests.
