### PR TITLE
Add a `exit` function for app exit. 

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -137,6 +137,10 @@ var App = Eventable.extend(function(self, start_state_name, opts) {
             return self.im.log.error(e.error.message);
         });
 
+        self.im.on('im:shutdown', function() {
+          return self.exit();
+        });
+
         return self
             .states.setup()
             .then(function() {
@@ -157,6 +161,17 @@ var App = Eventable.extend(function(self, start_state_name, opts) {
 
         Invoked just after setup has completed, and just before 'setup' event
         is fired to provide subclasses with a setup hook. May return a promise.
+        */
+    };
+
+    self.exit = function() {
+        /**:App.exit()
+
+        Invoked when the interaction machine has emitted an
+        :class:`IMShutdownEvent`, which occurs after the interaction machine
+        has finished processing the inbound message and has sent out a reply
+        (if relevant). Intended to be overriden and used as a 'teardown'
+        hook. May return a promise.
         */
     };
 

--- a/lib/interaction_machine.js
+++ b/lib/interaction_machine.js
@@ -839,6 +839,8 @@ this.InteractionMachine = InteractionMachine;
 this.interact = interact;
 
 this.IMEvent = IMEvent;
+this.IMErrorEvent = IMErrorEvent;
+this.IMShutdownEvent = IMShutdownEvent;
 this.InboundMessageEvent = InboundMessageEvent;
 this.InboundEventEvent = InboundEventEvent;
 this.UnknownCommandEvent = UnknownCommandEvent;

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -10,6 +10,7 @@ var App = vumigo.App;
 var AppStateError = vumigo.app.AppStateError;
 var AppTester = vumigo.AppTester;
 var Event = vumigo.events.Event;
+var IMShutdownEvent = vumigo.interaction_machine.IMShutdownEvent;
 
 
 describe("app", function() {
@@ -320,6 +321,13 @@ describe("app", function() {
                         assert(d.promise.isFulfilled());
                     });
             });
+        });
+
+        describe(".exit", function() {
+          it("should be invoked when the im is shutting down", function(done) {
+              app.exit = function() { done(); };
+              im.emit(new IMShutdownEvent(im));
+          });
         });
 
         describe(".setup", function() {


### PR DESCRIPTION
It would be the opposite of `init` and would allow for cleanup tasks after the application has generated a response. 

The idea is to provide a hook for logic that should happen after having generated a response, like maintenance http calls or cache cleanup stuff.
