### PR TITLE
Fix url formatting in http helper and dummy with node v0.11.15

### DIFF
--- a/lib/http/api.js
+++ b/lib/http/api.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var url_utils = require('url');
 
 var utils = require('../utils');
 var BaseError = utils.BaseError;
@@ -100,7 +99,7 @@ var HttpRequest = Extendable.extend(function(self, method, url, opts) {
 
     self.url = url;
     if (_.isString(self.url)) {
-        self.url = url_utils.format(url_utils.parse(url));
+        self.url = utils.url_without_params(self.url);
     }
 
     self.method = method.toUpperCase();
@@ -137,10 +136,7 @@ var HttpRequest = Extendable.extend(function(self, method, url, opts) {
         var cmd = {};
         cmd.data = {};
         cmd.name = 'http.' + self.method.toLowerCase();
-
-        var url_data = url_utils.parse(self.url);
-        url_data.query = self.params;
-        cmd.data.url = url_utils.format(url_data);
+        cmd.data.url = utils.url_with_params(self.url, self.params);
 
         if (self.headers !== null) {
             cmd.data.headers = self.headers;

--- a/lib/http/dummy.js
+++ b/lib/http/dummy.js
@@ -313,7 +313,6 @@ var DummyHttpResource = DummyResource.extend(function(self, name, opts) {
 
     self.request_from_cmd = function(cmd) {
         var method = cmd.cmd.split('.', 2)[1];
-        var url_data = url_utils.parse(cmd.url);
 
         var encoding;
         if ('Content-Type' in (cmd.headers || {})) {
@@ -327,7 +326,7 @@ var DummyHttpResource = DummyResource.extend(function(self, name, opts) {
             body: cmd.data,
             headers: cmd.headers,
             encoder: encoding.encoder,
-            params: querystring.decode(url_data.query),
+            params: utils.url_params(cmd.url),
             verify_options: cmd.verify_options,
             ssl_method: cmd.ssl_method
         }, utils.exists);
@@ -336,7 +335,7 @@ var DummyHttpResource = DummyResource.extend(function(self, name, opts) {
             opts.data = encoding.decoder(cmd.data);
         }
 
-        var url = url_utils.format(_.omit(url_data, 'search', 'query'));
+        var url = utils.url_without_params(cmd.url);
         var request = new HttpRequest(method, url, opts);
         request.encode();
         return request;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+var url_utils = require('url');
+var qs = require('querystring');
 var util = require('util');
 var _ = require('lodash');
 var moment = require('moment');
@@ -272,7 +274,8 @@ pretty.object = function(obj, opts) {
         .value();
 };
 
-normalize_msisdn = function(number, country_code) {
+
+function normalize_msisdn(number, country_code) {
     /**function:normalize_msisdn(number, country_code)
     Normalizes an MSISDN number.
 
@@ -305,7 +308,36 @@ normalize_msisdn = function(number, country_code) {
         }
     }
     return (number.match(/^\+/)) ? number : null;
-};
+}
+
+
+function url_params(url) {
+    var query = url_utils.parse(url).query;
+    return qs.decode(query);
+}
+
+
+function url_with_params(url, params) {
+    var d = url_utils.parse(url);
+
+    // https://github.com/joyent/node/issues/9070
+    d.path = null;
+
+    d.query = params;
+    return url_utils.format(d);
+}
+
+
+function url_without_params(url) {
+    var d = url_utils.parse(url);
+
+    // https://github.com/joyent/node/issues/9070
+    d.path = null;
+
+    d.search = null;
+    return url_utils.format(d);
+}
+
 
 function Extendable() {
     /**class:Extendable()
@@ -395,6 +427,9 @@ this.format_addr = format_addr;
 this.indent = indent;
 this.pretty = pretty;
 this.normalize_msisdn = normalize_msisdn;
+this.url_params = url_params;
+this.url_with_params = url_with_params;
+this.url_without_params = url_without_params;
 this.Extendable = Extendable;
 this.BaseError = BaseError;
 this.DeprectationError = DeprecationError;

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -287,4 +287,60 @@ describe("utils", function() {
                 '+27741234567');
         });
     });
+
+    describe(".url_params", function() {
+        it("should return the decoded querystring in a url", function() {
+            assert.deepEqual(utils.url_params('www.foo.com/?a=b&c=d&c=f'), {
+                a: 'b',
+                c: ['d', 'f']
+            });
+
+            assert.deepEqual(utils.url_params('www.foo.com/bar/?a=b&c=d'), {
+                a: 'b',
+                c: 'd'
+            });
+        });
+    });
+
+    describe("url_with_params", function() {
+        it("should join the url with the encoded params", function() {
+            var result;
+
+            result = utils.url_with_params('www.foo.com', {a: 'b'});
+            assert.equal(result, 'www.foo.com?a=b');
+
+            result = utils.url_with_params('www.foo.com/', {
+                a: 'b',
+                c: ['d', 'f']
+            });
+
+            assert.equal(result, 'www.foo.com/?a=b&c=d&c=f');
+
+            result = utils.url_with_params('www.foo.com/bar/', {
+                a: 'b',
+                c: 'd'
+            });
+
+            assert.equal(result, 'www.foo.com/bar/?a=b&c=d');
+        });
+    });
+
+    describe("url_without_params", function() {
+        it("should remove the querystring from the url", function() {
+            var result;
+
+            result = utils.url_with_params('www.foo.com/', {
+                a: 'b',
+                c: ['d', 'f']
+            });
+
+            assert.equal(
+                utils.url_without_params('www.foo.com/?a=b&c=d&c=f'),
+                'www.foo.com/');
+
+            assert.equal(
+                utils.url_without_params('www.foo.com/bar/?a=b^c=d'),
+                'www.foo.com/bar/');
+        });
+    });
 });


### PR DESCRIPTION
node v0.11.15's url module handles things a bit differently when parsing or formatting a url with params. The `path` field in the object returned by `url.parse` overrides the `query` field, so we need to unset `path` in order for the `query` field to be used as we need it to.

There is a ticket for this, but it seems possible that this behaviour is going to stay: https://github.com/joyent/node/issues/9070