### PR TITLE
Add default expiry for stored user state.

### DIFF
--- a/lib/kv/dummy.js
+++ b/lib/kv/dummy.js
@@ -24,6 +24,11 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
     */
     self.store = store || {};
 
+    /**attribute:DummyKvResource.expiry
+    An object mapping keys set to expire to their lifetime (in seconds).
+    */
+    self.expiry = {};
+
     self.incr = function(key, amount) {
         /**:DummyKvResource.incr(key[, amount])
 
@@ -63,6 +68,27 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
         return value;
     };
 
+    self.expire = function(key, seconds) {
+        /**:DummyKvResource.expire(key[, seconds])
+
+        Set or remove the expiry of a key.
+
+        If seconds is ``null``, the key is set not to expire.
+
+        :param string key:
+            The key to set the expiry for.
+        :param integer seconds:
+            The number of seconds to set the expiry to. Defaults to ``null``.
+        */
+        seconds = (typeof seconds !== 'undefined') ? seconds : null;
+        if (seconds === null) {
+            delete self.expiry[key];
+        }
+        else {
+            self.expiry[key] = seconds;
+        }
+    };
+
     self.handlers.get = function(cmd) {
         var value = self.store[cmd.key];
 
@@ -78,6 +104,7 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
 
     self.handlers.set = function(cmd) {
         self.store[cmd.key] = cmd.value;
+        self.expire(cmd.key, cmd.seconds);
         return {success: true};
     };
 

--- a/lib/kv/dummy.js
+++ b/lib/kv/dummy.js
@@ -24,10 +24,10 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
     */
     self.store = store || {};
 
-    /**attribute:DummyKvResource.expiry
+    /**attribute:DummyKvResource.ttl
     An object mapping keys set to expire to their lifetime (in seconds).
     */
-    self.expiry = {};
+    self.ttl = {};
 
     self.incr = function(key, amount) {
         /**:DummyKvResource.incr(key[, amount])
@@ -68,24 +68,25 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
         return value;
     };
 
-    self.expire = function(key, seconds) {
-        /**:DummyKvResource.expire(key[, seconds])
+    self.set_ttl = function(key, seconds) {
+        /**:DummyKvResource.set_ttl(key[, seconds])
 
-        Set or remove the expiry of a key.
+        Set or remove the ttl (expiry time) of a key.
 
-        If seconds is ``null`` or not given, the key is set not to expire.
+        If seconds is ``null`` or undefined the key is set not to expire (and
+        its ttl is removed).
 
         :param string key:
-            The key to set the expiry for.
+            The key to set the ttl for.
         :param integer seconds:
-            The number of seconds to set the expiry to. Defaults to ``null``.
+            The number of seconds to set the ttl to. Defaults to ``null``.
         */
         seconds = (typeof seconds !== 'undefined') ? seconds : null;
         if (seconds === null) {
-            delete self.expiry[key];
+            delete self.ttl[key];
         }
         else {
-            self.expiry[key] = seconds;
+            self.ttl[key] = seconds;
         }
     };
 
@@ -104,7 +105,7 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
 
     self.handlers.set = function(cmd) {
         self.store[cmd.key] = cmd.value;
-        self.expire(cmd.key, cmd.seconds);
+        self.set_ttl(cmd.key, cmd.seconds);
         return {success: true};
     };
 

--- a/lib/kv/dummy.js
+++ b/lib/kv/dummy.js
@@ -73,7 +73,7 @@ var DummyKvResource = DummyResource.extend(function(self, name, store) {
 
         Set or remove the expiry of a key.
 
-        If seconds is ``null``, the key is set not to expire.
+        If seconds is ``null`` or not given, the key is set not to expire.
 
         :param string key:
             The key to set the expiry for.

--- a/lib/user.js
+++ b/lib/user.js
@@ -341,17 +341,17 @@ var User = Eventable.extend(function(self, im) {
             });
     };
 
-    self.default_expiry = function() {
-        /**:User.default_expiry()
+    self.default_ttl = function() {
+        /**:User.default_ttl()
 
-        Returns the default expiry time in seconds.
+        Returns the default expiry time of saved user state (in seconds).
 
-        This may be set using the ``user_expiry`` sandbox config key. It
+        This may be set using the ``user_ttl`` sandbox config key. It
         defaults to 604800 seconds (seven days). Expiry may be disabled by
-        setting ``user_expiry`` to ``null``.
+        setting ``user_ttl`` to ``null``.
         */
-        var expiry = self.im.config.user_expiry;
-        return (typeof expiry !== 'undefined') ? expiry : 604800;
+        var ttl = self.im.config.user_ttl;
+        return (typeof ttl !== 'undefined') ? ttl : 604800;
     };
 
     self.save = function(opts) {
@@ -368,7 +368,7 @@ var User = Eventable.extend(function(self, im) {
         and events have been emitted.
         */
         opts = _.defaults(opts || {}, {
-            seconds: self.default_expiry(),
+            seconds: self.default_ttl(),
         });
         return self.im
             .api_request("kv.set", {

--- a/lib/user.js
+++ b/lib/user.js
@@ -341,19 +341,40 @@ var User = Eventable.extend(function(self, im) {
             });
     };
 
-    self.save = function() {
+    self.default_expiry = function() {
+        /**:User.default_expiry()
+
+        Returns the default expiry time in seconds.
+
+        This maybe be set using the ``user_expiry`` sandbox config key. It
+        defaults to 604800 seconds (seven days). Expiry may be disabled by
+        setting ``user_expiry`` to ``null``.
+        */
+        var expiry = self.im.config.user_expiry;
+        return (typeof expiry !== 'undefined') ? expiry : 604800;
+    };
+
+    self.save = function(opts) {
         /**:User.save()
 
         Save a user's current state to the key-value data store resource, then
         emits a :class:`UserSaveEvent`.
 
+        :param object opts.seconds:
+            How long the user's state should be stored for before expiring. See
+            :meth:`User.default_expiry` for how the default is determined.
+
         Returns a promise that is fulfilled once the user data has been saved
         and events have been emitted.
         */
+        opts = _.defaults(opts || {}, {
+            seconds: self.default_expiry(),
+        });
         return self.im
             .api_request("kv.set", {
                 key: self.key(),
-                value: self.serialize()
+                value: self.serialize(),
+                seconds: opts.seconds,
             })
             .then(function() {
                 return self.emit(new UserSaveEvent(self));

--- a/lib/user.js
+++ b/lib/user.js
@@ -362,7 +362,7 @@ var User = Eventable.extend(function(self, im) {
 
         :param object opts.seconds:
             How long the user's state should be stored for before expiring. See
-            :meth:`User.default_expiry` for how the default is determined.
+            :meth:`User.default_ttl` for how the default is determined.
 
         Returns a promise that is fulfilled once the user data has been saved
         and events have been emitted.

--- a/lib/user.js
+++ b/lib/user.js
@@ -346,7 +346,7 @@ var User = Eventable.extend(function(self, im) {
 
         Returns the default expiry time in seconds.
 
-        This maybe be set using the ``user_expiry`` sandbox config key. It
+        This may be set using the ``user_expiry`` sandbox config key. It
         defaults to 604800 seconds (seven days). Expiry may be disabled by
         setting ``user_expiry`` to ``null``.
         */

--- a/test/test_kv/test_dummy.js
+++ b/test/test_kv/test_dummy.js
@@ -72,6 +72,26 @@ describe("kv.dummy", function() {
             });
         });
 
+        describe(".expire", function() {
+            it("should set the expiry if given", function() {
+                assert.deepEqual(api.kv.expiry, {});
+                api.kv.expire("foo", 5);
+                assert.deepEqual(api.kv.expiry, {"foo": 5});
+            });
+
+            it("should unset the expiry if seconds is null", function() {
+                api.kv.expiry.foo = 10;
+                api.kv.expire("foo", null);
+                assert.deepEqual(api.kv.expiry, {});
+            });
+
+            it("should unset the expiry if seconds is undefined", function() {
+                api.kv.expiry.foo = 10;
+                api.kv.expire("foo");
+                assert.deepEqual(api.kv.expiry, {});
+            });
+        });
+
         describe(".handlers", function() {
             describe(".get", function() {
                 it("should retrieve the value for the given key", function() {

--- a/test/test_kv/test_dummy.js
+++ b/test/test_kv/test_dummy.js
@@ -123,6 +123,19 @@ describe("kv.dummy", function() {
                     }).then(function(reply) {
                         assert(reply.success);
                         assert.equal(api.kv.store.foo, 'bar');
+                        assert.equal(typeof api.kv.expiry.foo, 'undefined');
+                    });
+                });
+
+                it("should set an expiry if one is given", function() {
+                    return request('kv.set', {
+                        key: 'foo',
+                        value: 'bar',
+                        seconds: 15
+                    }).then(function(reply) {
+                        assert(reply.success);
+                        assert.equal(api.kv.store.foo, 'bar');
+                        assert.equal(api.kv.expiry.foo, 15);
                     });
                 });
             });

--- a/test/test_kv/test_dummy.js
+++ b/test/test_kv/test_dummy.js
@@ -72,23 +72,23 @@ describe("kv.dummy", function() {
             });
         });
 
-        describe(".expire", function() {
-            it("should set the expiry if given", function() {
-                assert.deepEqual(api.kv.expiry, {});
-                api.kv.expire("foo", 5);
-                assert.deepEqual(api.kv.expiry, {"foo": 5});
+        describe(".set_ttl", function() {
+            it("should set the ttl if given", function() {
+                assert.deepEqual(api.kv.ttl, {});
+                api.kv.set_ttl("foo", 5);
+                assert.deepEqual(api.kv.ttl, {"foo": 5});
             });
 
-            it("should unset the expiry if seconds is null", function() {
-                api.kv.expiry.foo = 10;
-                api.kv.expire("foo", null);
-                assert.deepEqual(api.kv.expiry, {});
+            it("should unset the ttl if seconds is null", function() {
+                api.kv.ttl.foo = 10;
+                api.kv.set_ttl("foo", null);
+                assert.deepEqual(api.kv.ttl, {});
             });
 
-            it("should unset the expiry if seconds is undefined", function() {
-                api.kv.expiry.foo = 10;
-                api.kv.expire("foo");
-                assert.deepEqual(api.kv.expiry, {});
+            it("should unset the ttl if seconds is undefined", function() {
+                api.kv.ttl.foo = 10;
+                api.kv.set_ttl("foo");
+                assert.deepEqual(api.kv.ttl, {});
             });
         });
 
@@ -123,7 +123,7 @@ describe("kv.dummy", function() {
                     }).then(function(reply) {
                         assert(reply.success);
                         assert.equal(api.kv.store.foo, 'bar');
-                        assert.equal(typeof api.kv.expiry.foo, 'undefined');
+                        assert.equal(typeof api.kv.ttl.foo, 'undefined');
                     });
                 });
 
@@ -135,7 +135,7 @@ describe("kv.dummy", function() {
                     }).then(function(reply) {
                         assert(reply.success);
                         assert.equal(api.kv.store.foo, 'bar');
-                        assert.equal(api.kv.expiry.foo, 15);
+                        assert.equal(api.kv.ttl.foo, 15);
                     });
                 });
             });

--- a/test/test_user.js
+++ b/test/test_user.js
@@ -194,20 +194,20 @@ describe("user", function() {
             });
         });
 
-        describe(".default_expiry", function() {
+        describe(".default_ttl", function() {
             it("should be seven days if no config is set", function() {
-                assert.strictEqual(user.default_expiry(), 604800);
+                assert.strictEqual(user.default_ttl(), 604800);
             });
 
             describe("should be overriden", function() {
-                it("when config.user_expiry is an integer", function() {
-                    im.config.user_expiry = 60;
-                    assert.strictEqual(user.default_expiry(), 60);
+                it("when config.user_ttl is an integer", function() {
+                    im.config.user_ttl = 60;
+                    assert.strictEqual(user.default_ttl(), 60);
                 });
 
-                it("when config.user_expiry is null", function() {
-                    im.config.user_expiry = null;
-                    assert.strictEqual(user.default_expiry(), null);
+                it("when config.user_ttl is null", function() {
+                    im.config.user_ttl = null;
+                    assert.strictEqual(user.default_ttl(), null);
                 });
             });
         });
@@ -239,17 +239,17 @@ describe("user", function() {
                     });
             });
 
-            it("should set the default expiry", function() {
+            it("should set the default ttl", function() {
                 return user
                     .save()
                     .then(function() {
                         assert.strictEqual(
                             im.api.kv.ttl[user.key()],
-                            user.default_expiry());
+                            user.default_ttl());
                     });
             });
 
-            it("should set an integer custom expiry", function() {
+            it("should set an integer custom ttl", function() {
                 return user
                     .save({seconds: 5})
                     .then(function() {
@@ -257,7 +257,7 @@ describe("user", function() {
                     });
             });
 
-            it("should set a null custom expiry", function() {
+            it("should not set a ttl for null seconds", function() {
                 return user
                     .save({seconds: null})
                     .then(function() {

--- a/test/test_user.js
+++ b/test/test_user.js
@@ -238,6 +238,33 @@ describe("user", function() {
                         assert.equal(e.user, user);
                     });
             });
+
+            it("should set the default expiry", function() {
+                return user
+                    .save()
+                    .then(function() {
+                        assert.strictEqual(
+                            im.api.kv.expiry[user.key()],
+                            user.default_expiry());
+                    });
+            });
+
+            it("should set an integer custom expiry", function() {
+                return user
+                    .save({seconds: 5})
+                    .then(function() {
+                        assert.strictEqual(im.api.kv.expiry[user.key()], 5);
+                    });
+            });
+
+            it("should set a null custom expiry", function() {
+                return user
+                    .save({seconds: null})
+                    .then(function() {
+                        assert.strictEqual(
+                            user.key() in im.api.kv.expiry, false);
+                    });
+            });
         });
 
         describe(".set_lang", function() {

--- a/test/test_user.js
+++ b/test/test_user.js
@@ -194,6 +194,24 @@ describe("user", function() {
             });
         });
 
+        describe(".default_expiry", function() {
+            it("should be seven days if no config is set", function() {
+                assert.strictEqual(user.default_expiry(), 604800);
+            });
+
+            describe("should be overriden", function() {
+                it("when config.user_expiry is an integer", function() {
+                    im.config.user_expiry = 60;
+                    assert.strictEqual(user.default_expiry(), 60);
+                });
+
+                it("when config.user_expiry is null", function() {
+                    im.config.user_expiry = null;
+                    assert.strictEqual(user.default_expiry(), null);
+                });
+            });
+        });
+
         describe(".save", function() {
             it("should save the user", function() {
                 user.set_answer('why', 'no');

--- a/test/test_user.js
+++ b/test/test_user.js
@@ -244,7 +244,7 @@ describe("user", function() {
                     .save()
                     .then(function() {
                         assert.strictEqual(
-                            im.api.kv.expiry[user.key()],
+                            im.api.kv.ttl[user.key()],
                             user.default_expiry());
                     });
             });
@@ -253,7 +253,7 @@ describe("user", function() {
                 return user
                     .save({seconds: 5})
                     .then(function() {
-                        assert.strictEqual(im.api.kv.expiry[user.key()], 5);
+                        assert.strictEqual(im.api.kv.ttl[user.key()], 5);
                     });
             });
 
@@ -262,7 +262,7 @@ describe("user", function() {
                     .save({seconds: null})
                     .then(function() {
                         assert.strictEqual(
-                            user.key() in im.api.kv.expiry, false);
+                            user.key() in im.api.kv.ttl, false);
                     });
             });
         });


### PR DESCRIPTION
We can't store data in redis indefinitely and people don't remember where they were in an application indefinitely either. Long-term state should be stored on contacts.

The plan is to default to a seven day expiry and allow it to be configured to a different expiry time or turned off entirely.