### PR TITLE
Return the fixture object when adding http fixtures

### DIFF
--- a/lib/http/dummy.js
+++ b/lib/http/dummy.js
@@ -242,17 +242,24 @@ var HttpFixtures = Extendable.extend(function(self, opts) {
         :param object data:
             The properties of the fixture to be added.
             See :class:`HttpFixture`.
+
+        :returns:
+            The :class:`HttpFixture` that was created.
         */
         /**HttpFixtures.add(fixture)
         Adds an already initialised fixture to the fixture set.
 
         :param HttpFixture fixture:
-            The fixture to be added
+            The fixture to be added.
+
+        :returns:
+            The :class:`HttpFixture` that was passed in.
         */
         if (!(obj instanceof HttpFixture)) {
             obj = self.create(obj);
         }
         self.fixtures.push(obj);
+        return obj;
     };
 
     self.create = function(data) {

--- a/test/test_http/test_dummy.js
+++ b/test/test_http/test_dummy.js
@@ -180,7 +180,7 @@ describe("http.dummy", function() {
             it("should support adding a fixture from data", function() {
                 var fixtures = new HttpFixtures();
 
-                fixtures.add({
+                var created_fixture = fixtures.add({
                     request: {url: 'http://example.com'},
                     response: {code: 201}
                 });
@@ -191,6 +191,7 @@ describe("http.dummy", function() {
                 assert(fixture instanceof HttpFixture);
                 assert.equal(fixture.request.url, 'http://example.com/');
                 assert.equal(fixture.responses[0].code, 201);
+                assert.strictEqual(created_fixture, fixture);
             });
 
             it("should support adding an already initialised fixture",
@@ -200,10 +201,11 @@ describe("http.dummy", function() {
                     request: {url: 'http://example.com'},
                     response: {code: 201}
                 });
-                fixtures.add(fixture);
+                var added_fixture = fixtures.add(fixture);
 
                 var request = new HttpRequest('get','http://example.com');
                 assert.equal(fixtures.filter(request)[0], fixture);
+                assert.strictEqual(added_fixture, fixture);
             });
         });
 


### PR DESCRIPTION
This is a convenience for cases where one wants to hang onto the fixture after creating it so that can assert things about it afterwards.