### PR TITLE
Improve PaginatedChoiceState page_size calculation

### DIFF
--- a/lib/states/choices.js
+++ b/lib/states/choices.js
@@ -121,11 +121,11 @@ var ChoiceState = State.extend(function(self, name, opts) {
         /**:ChoiceState.process_choice(choice)
         Return ``true`` if the choice has been handled completely or ``false``
         if the choice should be propagated to the next state handler.
-        
+
         This allows sub-classes to provide custom processing for special
         choices (e.g. forward and back options for navigating through long
         choice lists).
-        
+
         :param Choice choice: choice to be processed.
         */
         return false;
@@ -200,7 +200,7 @@ var ChoiceState = State.extend(function(self, name, opts) {
         var text = self.error
             ? self.error.response
             : self.question_text;
-            
+
         var choices = self.current_choices();
         choices = self.shorten_choices(text, choices);
         choices.forEach(function(choice, index) {
@@ -389,10 +389,12 @@ var PaginatedChoiceState = ChoiceState.extend(function(self, name, opts) {
         if (n !== null) return n;
 
         var chars = self._chars();
+        var page_choices = 1;
         n = self.metadata.page_start - 1;
 
         while (++n < self.choices.length) {
-            chars -= self.format_choice(self.choices[n], n).length;
+            chars -= self.format_choice(self.choices[n], page_choices).length;
+            page_choices++;
             if (chars < 0) break;
         }
 
@@ -404,10 +406,12 @@ var PaginatedChoiceState = ChoiceState.extend(function(self, name, opts) {
         if (n !== null) return n;
 
         var chars = self._chars();
+        var page_choices = 1;
         n = self.metadata.page_start;
 
         while (n-- > 0) {
-            chars -= self.format_choice(self.choices[n], n).length;
+            chars -= self.format_choice(self.choices[n], page_choices).length;
+            page_choices++;
             if (chars < 0) break;
         }
 

--- a/test/test_states/test_choices.js
+++ b/test/test_states/test_choices.js
@@ -472,7 +472,9 @@ describe("states.choice", function() {
                     new Choice('garply', 'Garply'),
                     new Choice('waldo', 'Waldo'),
                     new Choice('fred', 'Fred'),
-                    new Choice('plugh', 'Plugh')
+                    new Choice('plu', 'Plu'),
+                    new Choice('pli', 'Pli'),
+                    new Choice('plo', 'Plo')
                 ];
 
                 return Q()
@@ -533,15 +535,17 @@ describe("states.choice", function() {
                             .inputs(null, '4', '3', '3', '3')
                             .check.reply([
                                 "Hello.",
-                                "1. Plugh",
-                                "2. Back"
+                                "1. Plu",
+                                "2. Pli",
+                                "3. Plo",
+                                "4. Back"
                             ].join('\n'))
                             .check.reply.char_limit(opts.characters_per_page)
                             .run();
                     })
                     .then(function() {
                         return tester
-                            .inputs(null, '4', '3', '3', '3', '2')
+                            .inputs(null, '4', '3', '3', '3', '4')
                             .check.reply([
                                 "Hello.",
                                 "1. Waldo",
@@ -554,7 +558,7 @@ describe("states.choice", function() {
                     })
                     .then(function() {
                         return tester
-                            .inputs(null, '4', '3', '3', '3', '2', '4')
+                            .inputs(null, '4', '3', '3', '3', '4', '4')
                             .check.reply([
                                 "Hello.",
                                 "1. Grault",
@@ -567,7 +571,7 @@ describe("states.choice", function() {
                     })
                     .then(function() {
                         return tester
-                            .inputs(null, '4', '3', '3', '3', '2', '4', '4')
+                            .inputs(null, '4', '3', '3', '3', '4', '4', '4')
                             .check.reply([
                                 "Hello.",
                                 "1. Quux",
@@ -580,7 +584,7 @@ describe("states.choice", function() {
                     })
                     .then(function() {
                         return tester
-                            .inputs(null, '4', '3', '3', '3', '2', '4', '4', '4')
+                            .inputs(null, '4', '3', '3', '3', '4', '4', '4', '4')
                             .check.reply([
                                 "Hello.",
                                 "1. Foo",


### PR DESCRIPTION
Refer: https://github.com/praekelt/vumi-jssandbox-toolkit/blob/vumigo-0.2.13/lib/states/choices.js#L387
Suggestion: https://gist.github.com/gsvr/51b2c6acd41f8d17bdaf

The current use of `n` as second argument to `format_choice()` does not start at `1. `, but at the choice number. When there are 10+ choices we're losing available characters since it's calculating with `10. , 11.` in stead of `1. , 2.`.

My suggestion is a bit counter-intuitive for `_prev_page_size` since it's working semi backwards, but it should calculate the page size correctly.