### PR TITLE
Fix double-state creation when a new session goes straight to an end state.

### DIFF
--- a/lib/states/end.js
+++ b/lib/states/end.js
@@ -32,7 +32,7 @@ var EndState = State.extend(function(self, name, opts) {
     State.call(self, name, opts);
 
     self.on('setup', function() {
-        self.im.on('session:new', function() {
+        self.im.on('state:resume', function() {
             return self.set_next_state(self.next);
         });
     });

--- a/test/test_states/test_end.js
+++ b/test/test_states/test_end.js
@@ -39,6 +39,10 @@ describe("states.end", function() {
                 return new EndState(name, opts);
             });
 
+            app.states.add('states:delegate_to_end', function(name) {
+                return app.states.create('states:end');
+            });
+
             opts = {};
             tester = new AppTester(app);
         });
@@ -99,6 +103,35 @@ describe("states.end", function() {
                             .input({
                                 content: 'foo',
                                 session_event: null
+                            })
+                            .check.reply('hello')
+                            .check.user.state('states:start')
+                            .run();
+                    });
+            });
+        });
+
+        describe("when the state is delegated to at the start of a session",
+        function() {
+            it("should show the state, then the next state on a new session",
+            function() {
+                var user = tester.im.user;
+
+                return tester
+                    .setup.user.state('states:delegate_to_end')
+                    .input({
+                        content: null,
+                        session_event: 'new'
+                    })
+                    .check.user.state('states:end')
+                    .check.reply('goodbye')
+                    .run()
+                    .then(function() {
+                        return tester
+                            .setup.user(user.serialize())
+                            .input({
+                                content: null,
+                                session_event: 'new'
                             })
                             .check.reply('hello')
                             .check.user.state('states:start')


### PR DESCRIPTION
If a new session delegates to and end state, the state immediately moves to its next state when it should only do so after the start of the next session. The process is as follows:

* User starts session.
* Interaction machine attempts to create new state and ends up being delegated to a fresh end state that has never been displayed before.
* Interaction machine fires new session event (which must be fired after state creation so that the state can receive it).
* Fresh end state sets a new next state.
* Fresh end state is not displayed and interaction machine instead displays next state.