### PR TITLE
PaginatedState skips words

### DIFF
--- a/lib/states/paginated.js
+++ b/lib/states/paginated.js
@@ -89,7 +89,7 @@ var PaginatedState = State.extend(function(self, name, opts) {
     self.init = function() {
         self._text = null;
         self._current_choices = null;
-        self.page = self.page || self._page;
+        self.page = self.page || page_slice;
         _.defaults(self.metadata, {page: 0});
     };
 
@@ -157,28 +157,33 @@ var PaginatedState = State.extend(function(self, name, opts) {
         choices.push('exit');
         return choices;
     };
-
-    self._page = function(i, text, n) {
-        if (i * n > text.length) { return; }
-
-        var start;
-        if (i === 0) { start = 0; }
-        else if (i === 1) { start = last_space(n) + 1; }
-        else { start = end(last_space(n * (i - 1))) + 1; }
-
-        function end(start) {
-            return start + n < text.length
-                ? last_space(start + n)
-                : text.length;
-        }
-
-        function last_space(from) {
-            return text.lastIndexOf(' ', from);
-        }
-
-        return text.slice(start, end(start));
-    };
 });
+
+
+function page_slice(i, text, n) {
+    if (i * n > text.length) return null;
+    return text.slice(page_start(i, text, n), page_end(i, text, n));
+}
+
+
+function page_start(i, text, n) {
+    return i > 0
+        ? page_end(i - 1, text, n) + 1
+        : 0;
+}
+
+
+function page_end(i, text, n) {
+    var start = page_start(i, text, n);
+    return start + n < text.length
+        ? last_space(start + n, text)
+        : text.length;
+}
+
+
+function last_space(from, text) {
+    return text.lastIndexOf(' ', from);
+}
 
 
 this.PaginatedState = PaginatedState;

--- a/test/test_states/test_paginated.js
+++ b/test/test_states/test_paginated.js
@@ -325,6 +325,18 @@ describe("states.paginated", function() {
                                 "2. Exit",
                             ].join('\n'))
                             .run();
+                    })
+                    .then(function() {
+                        opts.text = 'a b c d e f g';
+
+                        return tester
+                            .inputs(null, '1', '1')
+                            .check.reply([
+                                "g",
+                                "1. Back",
+                                "2. Exit",
+                            ].join('\n'))
+                            .run();
                     });
             });
         });


### PR DESCRIPTION
PaginatedState sometimes skips words in the transition between pages.  Refer to this branch for a failing test: https://github.com/praekelt/go-refugeerights/tree/feature/issue-40-paginatedstate-words-dropped.

I also included 2 other text strings that experiences the same problem in case that's helpful.
