### PR TITLE
Validate headers on fixtures

### DIFF
--- a/lib/http/dummy.js
+++ b/lib/http/dummy.js
@@ -365,6 +365,15 @@ var DummyHttpResource = DummyResource.extend(function(self, name, opts) {
             ].join('\n'));
         }
 
+        _.forEach(request.headers, function (value, key) {
+            if (!_.isArray(value)) {
+                throw new DummyResourceError([
+                    "Header '" + key + "' must be an Array:",
+                    utils.indent(utils.pretty(request))
+                ]);
+            }
+        });
+
         var response = fixtures[0].use();
         self.requests.push(request);
 

--- a/test/test_http/test_dummy.js
+++ b/test/test_http/test_dummy.js
@@ -135,7 +135,7 @@ describe("http.dummy", function() {
 
                 fixture.use();
                 fixture.use();
-                
+
                 assert.equal(fixture.serialize().uses, 2);
             });
 
@@ -555,6 +555,20 @@ describe("http.dummy", function() {
                     });
                 });
 
+                it("should fail if there are any non-array headers", function() {
+                    api.http.fixtures.add({request: {url: /.*a.*/}});
+
+                    return request('http.get', {
+                        url: 'http://a.com',
+                        headers: {
+                            'foo': ['bar'],
+                            'bar': 'baz',
+                        }
+                    }).then(function(result) {
+                        assert(!result.success);
+                    });
+                });
+
                 it("should record the request", function() {
                     api.http.fixtures.add({
                         request: {
@@ -700,7 +714,7 @@ describe("http.dummy", function() {
                 }),
                 dummy.encodings.json);
         });
-        
+
         it("should fallback to a 'none' encoding", function() {
             assert.equal(
                 dummy.infer_encoding({'Content-Type': ['foo']}),


### PR DESCRIPTION
Currently any fixture HTTP header problems are ignored because they are not validated. For example: `'Authorization': 'Token blah'` would not get caught (it should be `'Authorization': ['Token blah']`)