### PR TITLE
AppTester check for creator_opts checks metadata instead of opts. 

### DIFF
--- a/lib/tester/checks.js
+++ b/lib/tester/checks.js
@@ -61,7 +61,7 @@ var CheckTasks = AppTesterTasks.extend(function(self, tester) {
         catch(e) {
             if (e instanceof assert.AssertionError) {
                 self.format_assertion_error(e, opts);
-            } 
+            }
 
             throw e;
         }
@@ -435,21 +435,21 @@ var CheckTasks = AppTesterTasks.extend(function(self, tester) {
         });
     };
 
-    self.methods.check.user.state.creator_opts = function(opts) {
-        /**function:AppTester.check.user.state.creator_opts(opts)
+    self.methods.check.user.state.creator_opts = function(creator_opts) {
+        /**function:AppTester.check.user.state.creator_opts(creator_opts)
 
         Checks that the creator options of the interaction machine's current
         state after a sandbox run deep equals the expected options.
 
-        :param object metadata:
-            the expected metadata of the current state
+        :param object creator_opts:
+            the expected creator_opts of the current state
 
         .. code-block:: javascript
 
             tester.check.user.state.creator_opts({foo: 'bar'});
         */
         var user = self.get_user();
-        self.assert.deepEqual(user.state.creator_opts, metadata, {
+        self.assert.deepEqual(user.state.creator_opts, creator_opts, {
             msg: "Unexpected user state creator options"
         });
     };

--- a/test/test_tester/test_checks.js
+++ b/test/test_tester/test_checks.js
@@ -618,6 +618,21 @@ describe("AppTester Check Tasks", function() {
         });
     });
 
+    describe(".check.user.state.creator_opts", function() {
+        it("should check the user's state's creator_opts", function() {
+            return tester
+                .setup.user.state('initial_state', {creator_opts: {foo: 'bar'}})
+                .check.user.state.creator_opts({foo: 'baz'})
+                .run()
+                .then(test_utils.fail, function(e) {
+                    assert.equal(
+                        e.msg, "Unexpected user state creator options");
+                    assert.deepEqual(e.expected, {foo: 'baz'});
+                    assert.deepEqual(e.actual, {foo: 'bar'});
+                });
+        });
+    });
+
     describe(".check.reply", function() {
         describe(".check.reply(content)", function() {
             it("should check the content of the sent reply", function() {
@@ -930,7 +945,7 @@ describe("AppTester Check Tasks", function() {
                 .run()
                 .then(test_utils.fail, function(e) {
                     assert.equal(
-                        e.msg, 
+                        e.msg,
                         "Expecting no replies from the app to the user");
 
                     assert.deepEqual(e.expected, []);


### PR DESCRIPTION
The method  self.methods.check.user.state.creator_opts checks metadata instead of opts when performing deep check. This results in ReferenceError: metadata is not defined. 