### PR TITLE
Support nested lazy text

### DIFF
--- a/lib/translate.js
+++ b/lib/translate.js
@@ -96,7 +96,16 @@ var LazyText = Extendable.extend(function(self, method, args) {
             The jed instance to translate with
         */
         var s = jed[self.method].apply(jed, self.args);
-        return _.template(s, self.ctx, LazyText.template_settings);
+        var ctx = self._resolve_ctx(jed);
+        return _.template(s, ctx, LazyText.template_settings);
+    };
+
+    self._resolve_ctx = function(jed) {
+        return _.mapValues(self.ctx, function(value) {
+            return value instanceof LazyText
+                ? value.apply_translation(jed)
+                : value;
+        });
     };
 });
 

--- a/test/test_translate.js
+++ b/test/test_translate.js
@@ -132,6 +132,21 @@ describe(".translate", function() {
 
                 assert.equal(result, 'daar is 3 ruimetewesers');
             });
+
+            it("should support nested lazy text", function() {
+                var $ = new LazyTranslator();
+                var lang = fixtures.lang('af');
+
+                lang.locale_data.messages["foo {{a}}"] = ["", "oof {{a}}", ""];
+                lang.locale_data.messages["bar {{b}}"] = ["", "rab {{b}}", ""];
+                lang.locale_data.messages["baz"] = ["", "zab", ""];
+
+                var result = $('foo {{a}}')
+                    .context({a: $('bar {{b}}').context({b: $('baz')})})
+                    .apply_translation(new Jed(lang));
+
+                assert.equal(result, 'oof rab zab');
+            });
         });
     });
 

--- a/test/test_translate.js
+++ b/test/test_translate.js
@@ -139,7 +139,7 @@ describe(".translate", function() {
 
                 lang.locale_data.messages["foo {{a}}"] = ["", "oof {{a}}", ""];
                 lang.locale_data.messages["bar {{b}}"] = ["", "rab {{b}}", ""];
-                lang.locale_data.messages["baz"] = ["", "zab", ""];
+                lang.locale_data.messages.baz = ["", "zab", ""];
 
                 var result = $('foo {{a}}')
                     .context({a: $('bar {{b}}').context({b: $('baz')})})


### PR DESCRIPTION
The use case driving this feature is that people want to be able to have common error messages, without the need to translate them for each case they are used in:

```js
var message = "{{prefix}}Please choose an option";

new ChoiceState({
  question: $(message).context(prefix: ''),
  error: $(message).context({prefix: errors.invalid_selection}),
  ...
});
```